### PR TITLE
Use `<table>` instead of Markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,20 @@ export default () => (
 <Banner year={2020} style={{ width: '256px' }} />
 ```
 
-| Prop    | Effect                                                 |
-| ------- | ------------------------------------------------------ |
-| `year`  | Number, one of `2016` to `2022`. Default: current year |
-| `style` | Object, for custom styles                              |
+<table>
+  <tr>
+    <th>Prop</th>
+    <th>Effect</th>
+  </tr>
+  <tr>
+    <td><code>year</code></td>
+    <td>Number, one of <code>2016</code> to <code>2022</code>. Default: current year</td>
+  </tr>
+  <tr>
+    <td><code>style</code></td>
+    <td>Object, for custom styles</td>
+  </tr>
+</table>
 
 ## License
 


### PR DESCRIPTION
### Why???

`@hackclub/markdown` only supports CommonMark, which doesn't seem to support the pipe-character table syntax. This means that https://hackclub.com/banner is kinda broken.

<img width="749" alt="Screen Shot 2022-05-03 at 4 47 39 PM" src="https://user-images.githubusercontent.com/34525547/166563246-d2c4fd74-f3b6-43c5-8fb3-443d32aa31ba.png">
